### PR TITLE
fix env

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -100,7 +100,7 @@ dependencies:
     - oauthlib==3.2.2
     - omegaconf==2.1.1
     - open-clip-torch==2.17.1
-    - opencv-contrib-python==4.3.0.36
+    - opencv-contrib-python==4.6.0.66
     - opencv-python==4.7.0.72
     - opencv-python-headless==4.7.0.72
     - orjson==3.9.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ gradio==3.39.0
 numpy==1.23.1
 omegaconf==2.1.1
 open_clip_torch==2.17.1
-opencv_contrib_python==4.3.0.36
+opencv_contrib_python==4.6.0.66
 opencv_python==4.7.0.72
 opencv_python_headless==4.7.0.72
 Pillow==9.4.0


### PR DESCRIPTION
Fix pip install error:
```
Could not find a version that satisfies the requirement opencv_contrib_python==[4.3.0.36]
```

Version `4.3.0.36` is no longer found on the pip source.